### PR TITLE
feat(config): modernize renovate preset and ci tooling

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+echo "Running pre-commit checks..."
+make lint-check
+make validate

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description
+
+
+
+## Related Issues  <!-- Remove this section if there are no related Issues -->
+
+* Closes #???
+
+## Related PRs  <!-- Remove this section if there are no related PRs -->
+
+
+
+<!-- See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword for more details on referring PRs from the same or a different repository and linking them to Issues. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,41 @@
 ---
-name: ci
+name: CI
 
 on: # yamllint disable-line rule:truthy
+  pull_request:
   push:
     branches:
       - "**"
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: latest
-      - name: Run the linter
-        run: npx --yes prettier --check .
+          node-version: lts/*
+
+      - name: Run linter
+        run: make lint-check
+
   validate:
+    name: Validate
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: latest
-      - name: Validate the configs
-        run: npx --yes --package=re2 --package=renovate -- renovate-config-validator default.json renovate.json
+          node-version: lts/*
+
+      - name: Validate configs
+        run: make validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: # yamllint disable-line rule:truthy
   pull_request:
   push:
     branches:
-      - "**"
+      - main
 
 jobs:
   lint:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.github/pull_request_template.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,12 +1,4 @@
 {
   "quoteProps": "consistent",
-  "trailingComma": "none",
-  "overrides": [
-    {
-      "files": "*.json5",
-      "options": {
-        "parser": "json"
-      }
-    }
-  ]
+  "trailingComma": "none"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Repository Philosophy
+
+This repository is a shared Renovate preset, not an application codebase.
+
+## Goals
+
+- Keep configuration predictable and easy to reuse.
+- Prefer stable, conservative defaults over aggressive automation.
+- Group noisy dependency streams (for example monorepos and stubs) to reduce PR churn.
+
+## Constraints
+
+- Keep repository tooling minimal: JSON, Makefile, GitHub Actions, and shell hooks.
+- Do not add runtime stack tooling (for example uv/poetry) unless the repository scope changes.
+- Use `npx`-based validation and formatting for local and CI parity.
+
+## Change rules
+
+- Validate every change with `make validate`.
+- Keep `default.json` compatible with official Renovate docs.
+- If changing update strategy, document rationale in README and PR description.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,13 @@ This repository is a shared Renovate preset, not an application codebase.
 - Validate every change with `make validate`.
 - Keep `default.json` compatible with official Renovate docs.
 - If changing update strategy, document rationale in README and PR description.
+
+## Commit & Pull Request Guidelines
+
+- Commit messages follow Conventional Commits and must include a scope, e.g. `feat(config): adjust lock file maintenance schedule`.
+- Include a concise summary and reference issues/PR numbers when applicable.
+- PRs should describe the change using template sections only.
+- Always use the repository PR template from `.github/pull_request_template.md`.
+- Follow inline comments in the PR template.
+- Remove template sections that are not applicable (for example, `Related Issues` or `Related PRs`).
+- Do not add ad-hoc sections (for example, `Impacted apps`, `Validation`, or standalone `Tests`) unless the template requires them.

--- a/Makefile
+++ b/Makefile
@@ -4,24 +4,37 @@
 
 .PHONY: help
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "Usage: \033[36mmake <target>\033[0m\n\nAwailable targets:\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: \033[36mmake <target>\033[0m\n\nAwailable targets:\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
 
+.PHONY: init
+init:  ## Initialize the development environment.
+	git config core.hooksPath .githooks
+
 .PHONY: lint
-lint: ## Run the linters.
+lint: ## Run linters/formatters.
 	npx --yes prettier --write .
+
+.PHONY: lint-check
+lint-check: ## Run linters in check mode.
+	npx --yes prettier --check .
 
 .PHONY: validate-renovate
 validate-renovate: ## Validate Renovate configuration files.
 	npx --yes --package=re2 --package=renovate -- renovate-config-validator default.json renovate.json
 
 .PHONY: validate-github-actions
-validate-github-actions: ## Validate GitHub Actions configuration file.
-	npx --yes --package=@action-validator/cli -- action-validator .github/workflows/ci.yml
+validate-github-actions: ## Validate GitHub Actions workflow files.
+	for filename in .github/workflows/*.yml; do npx --yes --package=@action-validator/cli -- action-validator "$$filename"; done
+
+.PHONY: validate
+validate: validate-renovate validate-github-actions ## Run all validators.
 
 .PHONY: clean
-clean: ## Remove all temporary files.
+clean: ## Remove all temporary files and unused git references.
 	git clean -fdX \
 		--exclude '!.vscode' \
 		--exclude '!.vscode/**'
+	git remote prune origin
+	git gc --aggressive

--- a/README.md
+++ b/README.md
@@ -1,39 +1,47 @@
 # renovate-config
 
-[Shareable config](https://docs.renovatebot.com/config-presets/) for [Renovate](https://www.mend.io/renovate/).
+Shareable [Renovate](https://www.mend.io/renovate/) preset for Vandruj repositories.
 
-## Setup
+## Setup in target repositories
 
-[Enable Renovate in your repo](https://github.com/apps/renovate/) and just use `extends` in the `renovate.json` or `renovate.json5` file.
+Enable Renovate for the target repository and extend this preset in `renovate.json` / `renovate.json5`:
 
-```js
+```json
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>YaraslauZhylko/renovate-config"]
 }
 ```
 
-## Development
+## Local development
 
-Lint the files:
+Initialize local git hooks:
+
+```shell
+make init
+```
+
+Run formatting:
 
 ```shell
 make lint
 ```
 
-Validate the configs:
+Run checks without changing files:
 
 ```shell
-make validate-renovate
+make lint-check
 ```
 
+Validate Renovate + GitHub Actions config:
+
 ```shell
-make validate-github-actions
+make validate
 ```
 
 ## References
 
-- [Renovate Docs](https://docs.renovatebot.com)
-- [Configuration Options \| Renovate Docs](https://docs.renovatebot.com/configuration-options/)
-- [Default Presets \| Renovate Docs](https://docs.renovatebot.com/presets-default/)
-- [Shareable Config Presets \| Renovate Docs](https://docs.renovatebot.com/config-presets/)
+- [Renovate Docs](https://docs.renovatebot.com/)
+- [Configuration Options | Renovate Docs](https://docs.renovatebot.com/configuration-options/)
+- [Default Presets | Renovate Docs](https://docs.renovatebot.com/presets-default/)
+- [Shareable Config Presets | Renovate Docs](https://docs.renovatebot.com/config-presets/)

--- a/default.json
+++ b/default.json
@@ -10,19 +10,8 @@
     ":rebaseStalePrs",
     ":automergeDisabled"
   ],
-  "prConcurrentLimit": 3,
-  "customManagers": [
-    {
-      "description": "Docker images in Makefile",
-      "customType": "regex",
-      "fileMatch": ["^Makefile$"],
-      "matchStrings": [
-        ".*_DOCKER_IMAGE\\s*=\\s*(?<depName>.+):(?<currentValue>.+)\\s*"
-      ],
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "docker"
-    }
-  ],
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 1,
   "packageRules": [
     {
       "description": "Docker: config",
@@ -44,12 +33,6 @@
       "addLabels": ["github-actions"]
     },
     {
-      "description": "JavaScript: config",
-      "matchCategories": ["js"],
-      "additionalBranchPrefix": "js/",
-      "addLabels": ["javascript"]
-    },
-    {
       "description": "Pre-commit: config",
       "matchManagers": ["pre-commit"],
       "additionalBranchPrefix": "pre-commit/",
@@ -65,7 +48,7 @@
     {
       "description": "Python: all types-* and *-stubs dependencies in one PR",
       "matchCategories": ["python"],
-      "matchPackagePatterns": ["^types-", "-stubs$"],
+      "matchPackageNames": ["types-*", "*-stubs"],
       "groupName": "types and stubs dependencies",
       "groupSlug": "types-and-stubs",
       "extends": ["schedule:weekly"]
@@ -87,6 +70,13 @@
       "groupSlug": "ruff"
     },
     {
+      "description": "Monorepo: yamllint dependencies",
+      "matchSourceUrls": ["https://github.com/adrienverge/yamllint"],
+      "additionalBranchPrefix": "monorepo/",
+      "groupName": "dependency yamllint",
+      "groupSlug": "yamllint"
+    },
+    {
       "description": "Monorepo: python Docker images",
       "matchDatasources": ["docker"],
       "matchDepNames": ["python"],
@@ -97,15 +87,20 @@
     {
       "description": "Monorepo: postgres Docker images",
       "matchDatasources": ["docker"],
-      "matchDepNames": ["postgres"],
+      "matchDepNames": ["postgres", "postgis/postgis"],
       "additionalBranchPrefix": "monorepo/",
       "groupName": "postgres docker tags",
       "groupSlug": "postgres"
+    },
+    {
+      "description": "Monorepo: redis Docker images",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["redis"],
+      "additionalBranchPrefix": "monorepo/",
+      "groupName": "redis docker tags",
+      "groupSlug": "redis"
     }
   ],
-  "pep621": {
-    "enabled": false
-  },
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
## Description

- refactor Renovate preset using relief-inspired modern defaults while preserving and merging monorepo rules
- add Docker grouping updates for postgres and postgis/postgis, and add Redis Docker monorepo grouping
- switch lock file maintenance to monthly and keep weekly grouped updates for types-* and *-stubs
- modernize repository automation with manual git hooks, improved Make targets, and refreshed GitHub Actions CI
- update README docs and add repository guidelines in AGENTS.md plus PR template